### PR TITLE
Changed the way, new ACL is handled to prevent call by reference prob…

### DIFF
--- a/PowerShell/Functions/Add-JsonAssemblyRedirect.ps1
+++ b/PowerShell/Functions/Add-JsonAssemblyRedirect.ps1
@@ -97,8 +97,11 @@ if($configFilesOnHost[$select]){
     # take ownership + grant fullcontrol permissions to config file
     Try {
         $originalACL = Get-ACL $appConfigPath -ErrorAction Stop
+        #Added to get around reference object copy. this will create an independent object
+        $newACL = Get-ACL $appConfigPath -ErrorAction Stop 
         Write-Output "`nRetrieved permissions on file $appConfigPath"
-        $newACL = $originalACL
+        #Removed as it will do a reference assignment, which will then change also the originalACL
+        #$newACL = $originalACL 
 
         $objUser    = New-Object System.Security.Principal.NTAccount($env:USERDOMAIN, $env:USERNAME)
         $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($objUser, "FullControl","Allow")


### PR DESCRIPTION
Changed the way, new ACL is handled to prevent call by reference problem. As ACL Objects do not have a Clone Method, I just call Get-ACL twice